### PR TITLE
Modify recompliations-per-second threshold

### DIFF
--- a/thresholds.tf
+++ b/thresholds.tf
@@ -33,7 +33,7 @@ locals {
     ReadLatencyThreshold                           = min(var.read_latency_threshold, 30)
     ReadThroughputEvaluationPeriods                = min(max(var.read_throughput_evaluation_periods, 1), 10)
     RecompilationsPerSecondEvaluationPeriods       = min(max(var.recompilations_per_second_evaluation_periods, 1), 10)
-    RecompilationsPerSecondThreshold               = min(var.recompilations_per_second_threshold, 30000)
+    RecompilationsPerSecondThreshold               = min(var.recompilations_per_second_threshold, 500000)
     SwapUsageEvaluationPeriods                     = min(max(var.swap_usage_evaluation_periods, 1), 10)
     SwapUsageThreshold                             = min(var.swap_usage_threshold, 100000000) #100M
     TempDbAvailableDataSpaceEvaluationPeriods      = min(max(var.temp_db_available_data_space_evaluation_periods, 1), 10)

--- a/variables.tf
+++ b/variables.tf
@@ -404,7 +404,7 @@ variable "recompilations_per_second_evaluation_periods" {
 variable "recompilations_per_second_threshold" {
   description = "The current value of mssql counter SQL Re-Compilations/sec. This is a cumulative (instance lifetime) value."
   type        = number
-  default     = 100000
+  default     = 300000
 }
 
 variable "sns_topic_name" {


### PR DESCRIPTION
Changing minimum threshold for recompliations-per-second alarm to be 300000 instead of 30000.