### PR TITLE
DIFF() cloudwatch alarm definitions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -864,8 +864,6 @@ resource "aws_cloudwatch_metric_alarm" "page_life_expectancy_static" {
   dimensions = {
     server_name = var.db_instance_id
   }
-  actions_enabled = false
-
 }
 
 # LockWaitsPerSecond anomaly alarm


### PR DESCRIPTION
Two alarms have been redefined to use the Cloudwatch DIFF() function. 
deadlocks_per_second_static is now deadlocks_per_second_diff_static
lock_waits_per_second_static is now lock_waits_per_second_diff_static